### PR TITLE
missing 'Browsing' keyword in logo

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@
                      \__, |\___/|___/\__,_|_.__/
                       __/ |  The Gateway to
                      |___/   Optimized Searching and
-                             Unlimited 
+                             Unlimited Browsing
 ```
 
 # 🙋‍♀️ A short introduction


### PR DESCRIPTION
just noticed that we were missing the 'Browsing' keyword in the logo on the main org README